### PR TITLE
Vulnerability: memory exposure tunnel agent

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-    "singleQuote": true
+    "singleQuote": true,
+    "tabWidth": 4
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "imagemin-webp-webpack-plugin",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -18,13 +18,10 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.1.tgz",
             "integrity": "sha512-KU/VDjC5RwtDUZiz3d+DHXJF2lp5hB9dn552TXIyptj8SH1vXmR40mG0JgGq03IlYsOgGfcv8xrLpSQ0YUMQdA=="
         },
-        "ansi-gray": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-            "requires": {
-                "ansi-wrap": "0.1.0"
-            }
+        "@sindresorhus/is": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+            "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -36,23 +33,23 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
-        "ansi-wrap": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+        "arch": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+            "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
         },
         "archive-type": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
-            "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
+            "integrity": "sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=",
             "requires": {
-                "file-type": "^3.1.0"
+                "file-type": "^4.2.0"
             },
             "dependencies": {
                 "file-type": {
-                    "version": "3.9.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-                    "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+                    "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
                 }
             }
         },
@@ -70,11 +67,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-        },
-        "array-differ": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
         },
         "array-find-index": {
             "version": "1.0.2",
@@ -108,11 +100,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-        },
-        "async-each-series": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
-            "integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg="
         },
         "atob": {
             "version": "2.1.2",
@@ -174,75 +161,206 @@
                 }
             }
         },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+        "base64-js": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+            "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
         },
         "bin-build": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
-            "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-3.0.0.tgz",
+            "integrity": "sha512-jcUOof71/TNAI2uM5uoUaDq2ePcVBQ3R/qhxAz1rX7UfvduAL/RXD3jXzvn8cVcDJdGVkiR1shal3OH0ImpuhA==",
             "requires": {
-                "archive-type": "^3.0.1",
-                "decompress": "^3.0.0",
-                "download": "^4.1.2",
-                "exec-series": "^1.0.0",
-                "rimraf": "^2.2.6",
-                "tempfile": "^1.0.0",
-                "url-regex": "^3.0.0"
+                "decompress": "^4.0.0",
+                "download": "^6.2.2",
+                "execa": "^0.7.0",
+                "p-map-series": "^1.0.0",
+                "tempfile": "^2.0.0"
             }
         },
         "bin-check": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
-            "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-4.1.0.tgz",
+            "integrity": "sha512-b6weQyEUKsDGFlACWSIOfveEnImkJyK/FGW6FAG42loyoquvjdtOIqO6yBFzHyqyVVhNgNkQxxx09SFLK28YnA==",
             "requires": {
-                "executable": "^1.0.0"
+                "execa": "^0.7.0",
+                "executable": "^4.1.0"
             }
         },
         "bin-version": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
-            "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-3.0.0.tgz",
+            "integrity": "sha512-Ekhwm6AUiMbZ1LgVCNMkgjovpMR30FyQN74laAW9gs0NPjZR5gdY0ARNB0YsQG8GOme3CsHbxmeyq/7Ofq6QYQ==",
             "requires": {
-                "find-versions": "^1.0.0"
-            }
-        },
-        "bin-version-check": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
-            "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
-            "requires": {
-                "bin-version": "^1.0.0",
-                "minimist": "^1.1.0",
-                "semver": "^4.0.3",
-                "semver-truncate": "^1.0.0"
+                "execa": "^1.0.0",
+                "find-versions": "^3.0.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
                 }
             }
         },
-        "bin-wrapper": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
-            "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
+        "bin-version-check": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-4.0.0.tgz",
+            "integrity": "sha512-sR631OrhC+1f8Cvs8WyVWOA33Y8tgwjETNPyyD/myRBXLkfS/vl74FmH/lFcRl9KY3zwGh7jFhvyk9vV3/3ilQ==",
             "requires": {
-                "bin-check": "^2.0.0",
-                "bin-version-check": "^2.1.0",
-                "download": "^4.0.0",
-                "each-async": "^1.1.1",
-                "lazy-req": "^1.0.0",
-                "os-filter-obj": "^1.0.0"
+                "bin-version": "^3.0.0",
+                "semver": "^5.6.0",
+                "semver-truncate": "^1.1.2"
+            }
+        },
+        "bin-wrapper": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-4.1.0.tgz",
+            "integrity": "sha512-hfRmo7hWIXPkbpi0ZltboCMVrU+0ClXR/JgbCKKjlDjQf6igXa7OwdqNcFWQZPZTgiY7ZpzE3+LjjkLiTN2T7Q==",
+            "requires": {
+                "bin-check": "^4.1.0",
+                "bin-version-check": "^4.0.0",
+                "download": "^7.1.0",
+                "import-lazy": "^3.1.0",
+                "os-filter-obj": "^2.0.0",
+                "pify": "^4.0.1"
+            },
+            "dependencies": {
+                "download": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/download/-/download-7.1.0.tgz",
+                    "integrity": "sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==",
+                    "requires": {
+                        "archive-type": "^4.0.0",
+                        "caw": "^2.0.1",
+                        "content-disposition": "^0.5.2",
+                        "decompress": "^4.2.0",
+                        "ext-name": "^5.0.0",
+                        "file-type": "^8.1.0",
+                        "filenamify": "^2.0.0",
+                        "get-stream": "^3.0.0",
+                        "got": "^8.3.1",
+                        "make-dir": "^1.2.0",
+                        "p-event": "^2.1.0",
+                        "pify": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+                        }
+                    }
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+                },
+                "got": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+                    "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+                    "requires": {
+                        "@sindresorhus/is": "^0.7.0",
+                        "cacheable-request": "^2.1.1",
+                        "decompress-response": "^3.3.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "into-stream": "^3.1.0",
+                        "is-retry-allowed": "^1.1.0",
+                        "isurl": "^1.0.0-alpha5",
+                        "lowercase-keys": "^1.0.0",
+                        "mimic-response": "^1.0.0",
+                        "p-cancelable": "^0.4.0",
+                        "p-timeout": "^2.0.1",
+                        "pify": "^3.0.0",
+                        "safe-buffer": "^5.1.1",
+                        "timed-out": "^4.0.1",
+                        "url-parse-lax": "^3.0.0",
+                        "url-to-options": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+                        }
+                    }
+                },
+                "p-cancelable": {
+                    "version": "0.4.1",
+                    "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+                    "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+                },
+                "p-event": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-event/-/p-event-2.1.0.tgz",
+                    "integrity": "sha512-sDEpDVnzLGlJj3k590uUdpfEUySP5yAYlvfTCu5hTDvSTXQVecYWKcEwdO49PrZlnJ5wkfAvtawnno/jyXeqvA==",
+                    "requires": {
+                        "p-timeout": "^2.0.1"
+                    }
+                },
+                "p-timeout": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+                    "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+                    "requires": {
+                        "p-finally": "^1.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+                },
+                "prepend-http": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+                },
+                "url-parse-lax": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+                    "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+                    "requires": {
+                        "prepend-http": "^2.0.0"
+                    }
+                }
             }
         },
         "bl": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+            "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "requires": {
                 "readable-stream": "^2.3.5",
@@ -285,6 +403,16 @@
                 }
             }
         },
+        "buffer": {
+            "version": "3.6.0",
+            "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+            "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+            "requires": {
+                "base64-js": "0.0.8",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
         "buffer-alloc": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -309,29 +437,6 @@
             "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
             "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
         },
-        "buffer-from": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-        },
-        "buffer-to-vinyl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
-            "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
-            "requires": {
-                "file-type": "^3.1.0",
-                "readable-stream": "^2.0.2",
-                "uuid": "^2.0.1",
-                "vinyl": "^1.0.0"
-            },
-            "dependencies": {
-                "file-type": {
-                    "version": "3.9.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-                    "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
-                }
-            }
-        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -353,6 +458,32 @@
                 "unset-value": "^1.0.0"
             }
         },
+        "cacheable-request": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+            "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+            "requires": {
+                "clone-response": "1.0.2",
+                "get-stream": "3.0.0",
+                "http-cache-semantics": "3.8.1",
+                "keyv": "3.0.0",
+                "lowercase-keys": "1.0.0",
+                "normalize-url": "2.0.1",
+                "responselike": "1.0.2"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+                },
+                "lowercase-keys": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                    "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+                }
+            }
+        },
         "call-me-maybe": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -365,39 +496,27 @@
         },
         "camelcase-keys": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "requires": {
                 "camelcase": "^2.0.0",
                 "map-obj": "^1.0.0"
             }
         },
-        "capture-stack-trace": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-            "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
-        },
         "caw": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
-            "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
+            "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
             "requires": {
-                "get-proxy": "^1.0.1",
-                "is-obj": "^1.0.0",
-                "object-assign": "^3.0.0",
-                "tunnel-agent": "^0.4.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-                }
+                "get-proxy": "^2.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "tunnel-agent": "^0.6.0",
+                "url-to-options": "^1.0.1"
             }
         },
         "chalk": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
                 "ansi-styles": "^2.2.1",
@@ -428,20 +547,13 @@
                 }
             }
         },
-        "clone": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-        },
-        "clone-stats": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-        },
-        "co": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-            "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+        "clone-response": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+            "requires": {
+                "mimic-response": "^1.0.0"
+            }
         },
         "collection-visit": {
             "version": "1.0.0",
@@ -452,14 +564,9 @@
                 "object-visit": "^1.0.0"
             }
         },
-        "color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-        },
         "commander": {
             "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+            "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
             "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
             "requires": {
                 "graceful-readlink": ">= 1.0.0"
@@ -475,15 +582,13 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
-        "concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+        "config-chain": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+            "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
             }
         },
         "console-stream": {
@@ -491,10 +596,10 @@
             "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
             "integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ="
         },
-        "convert-source-map": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+        "content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
         },
         "copy-descriptor": {
             "version": "0.1.1",
@@ -505,14 +610,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "create-error-class": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-            "requires": {
-                "capture-stack-trace": "^1.0.0"
-            }
         },
         "cross-spawn": {
             "version": "5.1.0",
@@ -533,19 +630,14 @@
             }
         },
         "cwebp-bin": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-4.0.0.tgz",
-            "integrity": "sha1-7it/YzPTQm+1K7QF+m8uyLYolPQ=",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-5.0.0.tgz",
+            "integrity": "sha512-7//DAQG0yFr+YGrQ0of50sPlPm+8mIRv1TGxXtlOeq1S0Y56iY2lHlX/aLz+AOTWH/2YVNthNtH97pxRl7q33A==",
             "requires": {
-                "bin-build": "^2.2.0",
-                "bin-wrapper": "^3.0.1",
-                "logalot": "^2.0.0"
+                "bin-build": "^3.0.0",
+                "bin-wrapper": "^4.0.1",
+                "logalot": "^2.1.0"
             }
-        },
-        "dateformat": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-            "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
         },
         "debug": {
             "version": "2.6.9",
@@ -566,138 +658,110 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "decompress": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
-            "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+            "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
             "requires": {
-                "buffer-to-vinyl": "^1.0.0",
-                "concat-stream": "^1.4.6",
-                "decompress-tar": "^3.0.0",
-                "decompress-tarbz2": "^3.0.0",
-                "decompress-targz": "^3.0.0",
-                "decompress-unzip": "^3.0.0",
-                "stream-combiner2": "^1.1.1",
-                "vinyl-assign": "^1.0.1",
-                "vinyl-fs": "^2.2.0"
+                "decompress-tar": "^4.0.0",
+                "decompress-tarbz2": "^4.0.0",
+                "decompress-targz": "^4.0.0",
+                "decompress-unzip": "^4.0.1",
+                "graceful-fs": "^4.1.10",
+                "make-dir": "^1.0.0",
+                "pify": "^2.3.0",
+                "strip-dirs": "^2.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                }
+            }
+        },
+        "decompress-response": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "requires": {
+                "mimic-response": "^1.0.0"
             }
         },
         "decompress-tar": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
-            "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "requires": {
-                "is-tar": "^1.0.0",
-                "object-assign": "^2.0.0",
-                "strip-dirs": "^1.0.0",
-                "tar-stream": "^1.1.1",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.3"
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0",
+                "tar-stream": "^1.5.2"
             },
             "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
-                    }
+                "file-type": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+                    "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
                 }
             }
         },
         "decompress-tarbz2": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
-            "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "requires": {
-                "is-bzip2": "^1.0.0",
-                "object-assign": "^2.0.0",
-                "seek-bzip": "^1.0.3",
-                "strip-dirs": "^1.0.0",
-                "tar-stream": "^1.1.1",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.3"
+                "decompress-tar": "^4.1.0",
+                "file-type": "^6.1.0",
+                "is-stream": "^1.1.0",
+                "seek-bzip": "^1.0.5",
+                "unbzip2-stream": "^1.0.9"
             },
             "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
-                    }
+                "file-type": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+                    "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
                 }
             }
         },
         "decompress-targz": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
-            "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "requires": {
-                "is-gzip": "^1.0.0",
-                "object-assign": "^2.0.0",
-                "strip-dirs": "^1.0.0",
-                "tar-stream": "^1.1.1",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.3"
+                "decompress-tar": "^4.1.1",
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0"
             },
             "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
-                    }
+                "file-type": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+                    "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
                 }
             }
         },
         "decompress-unzip": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
-            "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+            "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
             "requires": {
-                "is-zip": "^1.0.0",
-                "read-all-stream": "^3.0.0",
-                "stat-mode": "^0.2.0",
-                "strip-dirs": "^1.0.0",
-                "through2": "^2.0.0",
-                "vinyl": "^1.0.0",
-                "yauzl": "^2.2.1"
+                "file-type": "^3.8.0",
+                "get-stream": "^2.2.0",
+                "pify": "^2.3.0",
+                "yauzl": "^2.4.2"
             },
             "dependencies": {
-                "through2": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-                    "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
-                    }
+                "file-type": {
+                    "version": "3.9.0",
+                    "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+                    "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                 }
             }
-        },
-        "deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "define-property": {
             "version": "2.0.2",
@@ -746,61 +810,39 @@
             }
         },
         "download": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
-            "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
+            "version": "6.2.5",
+            "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
+            "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
             "requires": {
-                "caw": "^1.0.1",
-                "concat-stream": "^1.4.7",
-                "each-async": "^1.0.0",
-                "filenamify": "^1.0.1",
-                "got": "^5.0.0",
-                "gulp-decompress": "^1.2.0",
-                "gulp-rename": "^1.2.0",
-                "is-url": "^1.2.0",
-                "object-assign": "^4.0.1",
-                "read-all-stream": "^3.0.0",
-                "readable-stream": "^2.0.2",
-                "stream-combiner2": "^1.1.1",
-                "vinyl": "^1.0.0",
-                "vinyl-fs": "^2.2.0",
-                "ware": "^1.2.0"
+                "caw": "^2.0.0",
+                "content-disposition": "^0.5.2",
+                "decompress": "^4.0.0",
+                "ext-name": "^5.0.0",
+                "file-type": "5.2.0",
+                "filenamify": "^2.0.0",
+                "get-stream": "^3.0.0",
+                "got": "^7.0.0",
+                "make-dir": "^1.0.0",
+                "p-event": "^1.0.0",
+                "pify": "^3.0.0"
             },
             "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                "file-type": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+                    "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
                 }
             }
         },
-        "duplexer2": {
+        "duplexer3": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-            "requires": {
-                "readable-stream": "^2.0.2"
-            }
-        },
-        "duplexify": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-            "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
-            "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
-            }
-        },
-        "each-async": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
-            "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
-            "requires": {
-                "onetime": "^1.0.0",
-                "set-immediate-shim": "^1.0.0"
-            }
+            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "end-of-stream": {
             "version": "1.4.1",
@@ -833,38 +875,6 @@
                 "pify": "^3.0.0",
                 "rimraf": "^2.5.4",
                 "tempfile": "^2.0.0"
-            },
-            "dependencies": {
-                "tempfile": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
-                    "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
-                    "requires": {
-                        "temp-dir": "^1.0.0",
-                        "uuid": "^3.0.1"
-                    }
-                },
-                "uuid": {
-                    "version": "3.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-                }
-            }
-        },
-        "exec-series": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
-            "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
-            "requires": {
-                "async-each-series": "^1.1.0",
-                "object-assign": "^4.1.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                }
             }
         },
         "execa": {
@@ -879,14 +889,28 @@
                 "p-finally": "^1.0.0",
                 "signal-exit": "^3.0.0",
                 "strip-eof": "^1.0.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+                }
             }
         },
         "executable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
-            "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+            "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
             "requires": {
-                "meow": "^3.1.0"
+                "pify": "^2.2.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                }
             }
         },
         "expand-brackets": {
@@ -921,56 +945,22 @@
                 }
             }
         },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+        "ext-list": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+            "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
             "requires": {
-                "fill-range": "^2.1.0"
-            },
-            "dependencies": {
-                "fill-range": {
-                    "version": "2.2.4",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-                    "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^3.0.0",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
-                    }
-                },
-                "is-number": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                },
-                "isobject": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                    "requires": {
-                        "isarray": "1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
+                "mime-db": "^1.28.0"
             }
         },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        "ext-name": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+            "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+            "requires": {
+                "ext-list": "^2.0.0",
+                "sort-keys-length": "^1.0.0"
+            }
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -1050,16 +1040,6 @@
                 }
             }
         },
-        "fancy-log": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
-            "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-            "requires": {
-                "ansi-gray": "^0.1.1",
-                "color-support": "^1.1.3",
-                "time-stamp": "^1.0.0"
-            }
-        },
         "fast-glob": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
@@ -1088,13 +1068,6 @@
             "requires": {
                 "escape-string-regexp": "^1.0.5",
                 "object-assign": "^4.1.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                }
             }
         },
         "file-type": {
@@ -1102,22 +1075,17 @@
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
             "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-        },
         "filename-reserved-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-            "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
         },
         "filenamify": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
-            "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+            "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
             "requires": {
-                "filename-reserved-regex": "^1.0.0",
+                "filename-reserved-regex": "^2.0.0",
                 "strip-outer": "^1.0.0",
                 "trim-repeated": "^1.0.0"
             }
@@ -1153,33 +1121,25 @@
             }
         },
         "find-versions": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
-            "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.0.0.tgz",
+            "integrity": "sha512-IUvtItVFNmTtKoB0PRfbkR0zR9XMG5rWNO3qI1S8L0zdv+v2gqzM0pAunloxqbqAfT8w7bg8n/5gHzTXte8H5A==",
             "requires": {
-                "array-uniq": "^1.0.0",
-                "get-stdin": "^4.0.1",
-                "meow": "^3.5.0",
-                "semver-regex": "^1.0.0"
+                "array-uniq": "^2.0.0",
+                "semver-regex": "^2.0.0"
+            },
+            "dependencies": {
+                "array-uniq": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
+                    "integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg=="
+                }
             }
-        },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
         },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-        },
-        "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "requires": {
-                "for-in": "^1.0.1"
-            }
         },
         "fragment-cache": {
             "version": "0.2.1",
@@ -1187,6 +1147,15 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "requires": {
                 "map-cache": "^0.2.2"
+            }
+        },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
             }
         },
         "fs-constants": {
@@ -1200,11 +1169,11 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "get-proxy": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
-            "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
+            "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
             "requires": {
-                "rc": "^1.1.2"
+                "npm-conf": "^1.1.0"
             }
         },
         "get-stdin": {
@@ -1213,9 +1182,13 @@
             "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
         },
         "get-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            "version": "2.3.1",
+            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+            "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+            "requires": {
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
+            }
         },
         "get-value": {
             "version": "2.0.6",
@@ -1235,38 +1208,6 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "requires": {
-                        "is-glob": "^2.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
-            }
-        },
         "glob-parent": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -1282,115 +1223,6 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "requires": {
                         "is-extglob": "^2.1.0"
-                    }
-                }
-            }
-        },
-        "glob-stream": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-            "requires": {
-                "extend": "^3.0.0",
-                "glob": "^5.0.3",
-                "glob-parent": "^3.0.0",
-                "micromatch": "^2.3.7",
-                "ordered-read-streams": "^0.3.0",
-                "through2": "^0.6.0",
-                "to-absolute-glob": "^0.1.1",
-                "unique-stream": "^2.0.2"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
                     }
                 }
             }
@@ -1414,155 +1246,43 @@
                 "slash": "^1.0.0"
             }
         },
-        "glogg": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-            "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
-            "requires": {
-                "sparkles": "^1.0.0"
-            }
-        },
         "got": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-            "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+            "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
             "requires": {
-                "create-error-class": "^3.0.1",
-                "duplexer2": "^0.1.4",
-                "is-redirect": "^1.0.0",
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
                 "is-retry-allowed": "^1.0.0",
                 "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
                 "lowercase-keys": "^1.0.0",
-                "node-status-codes": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "parse-json": "^2.1.0",
-                "pinkie-promise": "^2.0.0",
-                "read-all-stream": "^3.0.0",
-                "readable-stream": "^2.0.5",
-                "timed-out": "^3.0.0",
-                "unzip-response": "^1.0.2",
-                "url-parse-lax": "^1.0.0"
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
             },
             "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
                 }
             }
         },
         "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
         },
         "graceful-readlink": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-        },
-        "gulp-decompress": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
-            "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
-            "requires": {
-                "archive-type": "^3.0.0",
-                "decompress": "^3.0.0",
-                "gulp-util": "^3.0.1",
-                "readable-stream": "^2.0.2"
-            }
-        },
-        "gulp-rename": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.4.0.tgz",
-            "integrity": "sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg=="
-        },
-        "gulp-sourcemaps": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-            "requires": {
-                "convert-source-map": "^1.1.1",
-                "graceful-fs": "^4.1.2",
-                "strip-bom": "^2.0.0",
-                "through2": "^2.0.0",
-                "vinyl": "^1.0.0"
-            },
-            "dependencies": {
-                "through2": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-                    "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-util": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-            "requires": {
-                "array-differ": "^1.0.0",
-                "array-uniq": "^1.0.2",
-                "beeper": "^1.0.0",
-                "chalk": "^1.0.0",
-                "dateformat": "^2.0.0",
-                "fancy-log": "^1.1.0",
-                "gulplog": "^1.0.0",
-                "has-gulplog": "^0.1.0",
-                "lodash._reescape": "^3.0.0",
-                "lodash._reevaluate": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.template": "^3.0.0",
-                "minimist": "^1.1.0",
-                "multipipe": "^0.1.2",
-                "object-assign": "^3.0.0",
-                "replace-ext": "0.0.1",
-                "through2": "^2.0.0",
-                "vinyl": "^0.5.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-                },
-                "through2": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-                    "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.5.3",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-                    "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-                    "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
-            }
-        },
-        "gulplog": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "requires": {
-                "glogg": "^1.0.0"
-            }
         },
         "has-ansi": {
             "version": "2.0.0",
@@ -1572,12 +1292,17 @@
                 "ansi-regex": "^2.0.0"
             }
         },
-        "has-gulplog": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+        "has-symbol-support-x": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+            "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+        },
+        "has-to-string-tag-x": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+            "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
             "requires": {
-                "sparkles": "^1.0.0"
+                "has-symbol-support-x": "^1.4.1"
             }
         },
         "has-value": {
@@ -1614,6 +1339,16 @@
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
             "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
         },
+        "http-cache-semantics": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+            "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+        },
+        "ieee754": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+            "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+        },
         "ignore": {
             "version": "3.3.10",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
@@ -1633,14 +1368,19 @@
             }
         },
         "imagemin-webp": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-4.1.0.tgz",
-            "integrity": "sha1-7/0AFg2EVrlcveX9JsMtZLAxgGI=",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-5.0.0.tgz",
+            "integrity": "sha512-e3LnIlitWfyGzYGPwaKdne7hIawgewHPKW+Sf2KgG96hzStqwDguOrzsi5srWZY0QrtxjfmJbw5UYES9N59Rtg==",
             "requires": {
-                "cwebp-bin": "^4.0.0",
+                "cwebp-bin": "^5.0.0",
                 "exec-buffer": "^3.0.0",
                 "is-cwebp-readable": "^2.0.1"
             }
+        },
+        "import-lazy": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+            "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ=="
         },
         "indent-string": {
             "version": "2.1.0",
@@ -1669,17 +1409,13 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
-        "ip-regex": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-            "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0="
-        },
-        "is-absolute": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-            "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+        "into-stream": {
+            "version": "3.1.0",
+            "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+            "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
             "requires": {
-                "is-relative": "^0.1.0"
+                "from2": "^2.1.1",
+                "p-is-promise": "^1.1.0"
             }
         },
         "is-accessor-descriptor": {
@@ -1712,16 +1448,11 @@
         },
         "is-builtin-module": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "requires": {
                 "builtin-modules": "^1.0.0"
             }
-        },
-        "is-bzip2": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
-            "integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w="
         },
         "is-cwebp-readable": {
             "version": "2.0.1",
@@ -1773,19 +1504,6 @@
                 }
             }
         },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "requires": {
-                "is-primitive": "^2.0.0"
-            }
-        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -1812,15 +1530,10 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-gzip": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-            "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
-        },
         "is-natural-number": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
-            "integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec="
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+            "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
         },
         "is-number": {
             "version": "3.0.0",
@@ -1840,10 +1553,15 @@
                 }
             }
         },
-        "is-obj": {
+        "is-object": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+            "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+            "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+        },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -1852,26 +1570,6 @@
             "requires": {
                 "isobject": "^3.0.1"
             }
-        },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-        },
-        "is-redirect": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-        },
-        "is-relative": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-            "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI="
         },
         "is-retry-allowed": {
             "version": "1.1.0",
@@ -1883,35 +1581,15 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
-        "is-tar": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
-            "integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0="
-        },
-        "is-url": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
-        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
         },
-        "is-valid-glob": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
-        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-        },
-        "is-zip": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
-            "integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU="
         },
         "isarray": {
             "version": "1.0.0",
@@ -1928,40 +1606,36 @@
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
-        "json-stable-stringify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+        "isurl": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+            "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
             "requires": {
-                "jsonify": "~0.0.0"
+                "has-to-string-tag-x": "^1.2.0",
+                "is-object": "^1.0.1"
             }
         },
-        "jsonify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+        "json-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+        },
+        "keyv": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+            "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+            "requires": {
+                "json-buffer": "3.0.0"
+            }
         },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
-        "lazy-req": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
-            "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
-        },
-        "lazystream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-            "requires": {
-                "readable-stream": "^2.0.5"
-            }
-        },
         "load-json-file": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -1973,117 +1647,9 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                 }
-            }
-        },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-        },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
-        },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-        },
-        "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "requires": {
-                "lodash._root": "^3.0.0"
-            }
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
-            }
-        },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-        },
-        "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash._basetostring": "^3.0.0",
-                "lodash._basevalues": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0",
-                "lodash.keys": "^3.0.0",
-                "lodash.restparam": "^3.0.0",
-                "lodash.templatesettings": "^3.0.0"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "requires": {
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0"
             }
         },
         "logalot": {
@@ -2126,9 +1692,9 @@
             }
         },
         "lru-cache": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-            "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
             "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -2160,14 +1726,9 @@
                 "object-visit": "^1.0.0"
             }
         },
-        "math-random": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
-        },
         "meow": {
             "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "requires": {
                 "camelcase-keys": "^2.0.0",
@@ -2180,21 +1741,6 @@
                 "read-pkg-up": "^1.0.1",
                 "redent": "^1.0.0",
                 "trim-newlines": "^1.0.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                }
-            }
-        },
-        "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "requires": {
-                "readable-stream": "^2.0.1"
             }
         },
         "merge2": {
@@ -2222,6 +1768,16 @@
                 "to-regex": "^3.0.2"
             }
         },
+        "mime-db": {
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+        },
+        "mimic-response": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2232,7 +1788,7 @@
         },
         "minimist": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mixin-deep": {
@@ -2254,64 +1810,10 @@
                 }
             }
         },
-        "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "requires": {
-                "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                }
-            }
-        },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "requires": {
-                "duplexer2": "0.0.2"
-            },
-            "dependencies": {
-                "duplexer2": {
-                    "version": "0.0.2",
-                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                    "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-                    "requires": {
-                        "readable-stream": "~1.1.9"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                    "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                }
-            }
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -2331,10 +1833,10 @@
                 "to-regex": "^3.0.1"
             }
         },
-        "node-status-codes": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-            "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "normalize-package-data": {
             "version": "2.4.0",
@@ -2347,12 +1849,38 @@
                 "validate-npm-package-license": "^3.0.1"
             }
         },
-        "normalize-path": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+        "normalize-url": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+            "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "prepend-http": "^2.0.0",
+                "query-string": "^5.0.1",
+                "sort-keys": "^2.0.0"
+            },
+            "dependencies": {
+                "prepend-http": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+                },
+                "sort-keys": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+                    "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+                    "requires": {
+                        "is-plain-obj": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "npm-conf": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+            "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+            "requires": {
+                "config-chain": "^1.1.11",
+                "pify": "^3.0.0"
             }
         },
         "npm-run-path": {
@@ -2369,9 +1897,9 @@
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-            "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-copy": {
             "version": "0.1.0",
@@ -2409,15 +1937,6 @@
                 "isobject": "^3.0.0"
             }
         },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
-            }
-        },
         "object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -2434,64 +1953,61 @@
                 "wrappy": "1"
             }
         },
-        "onetime": {
-            "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-        },
-        "ordered-read-streams": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+        "os-filter-obj": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-2.0.0.tgz",
+            "integrity": "sha512-uksVLsqG3pVdzzPvmAHpBK0wKxYItuzZr7SziusRPoz67tGV8rL1szZ6IdeUrbqLjGDwApBtN29eEE3IqGHOjg==",
             "requires": {
-                "is-stream": "^1.0.1",
-                "readable-stream": "^2.0.1"
+                "arch": "^2.1.0"
             }
         },
-        "os-filter-obj": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
-            "integrity": "sha1-WRUzDZDs7VV9LZOKMcbdIU2cY60="
+        "p-cancelable": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+            "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
         },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        "p-event": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz",
+            "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
+            "requires": {
+                "p-timeout": "^1.1.1"
+            }
         },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
+        "p-is-promise": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+            "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+        },
+        "p-map-series": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+            "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
+            "requires": {
+                "p-reduce": "^1.0.0"
+            }
+        },
         "p-pipe": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
             "integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k="
         },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+        "p-reduce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+            "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+        },
+        "p-timeout": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+            "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
+                "p-finally": "^1.0.0"
             }
         },
         "parse-json": {
@@ -2571,56 +2087,38 @@
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
             "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-        },
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
         },
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
-        "randomatic": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-            "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-                }
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
-        "rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+        "query-string": {
+            "version": "5.1.1",
+            "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+            "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
             "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            }
-        },
-        "read-all-stream": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-            "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-            "requires": {
-                "pinkie-promise": "^2.0.0",
-                "readable-stream": "^2.0.0"
+                "decode-uri-component": "^0.2.0",
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
             }
         },
         "read-pkg": {
@@ -2645,7 +2143,7 @@
                 },
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                 }
             }
@@ -2661,7 +2159,7 @@
         },
         "readable-stream": {
             "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
                 "core-util-is": "~1.0.0",
@@ -2682,14 +2180,6 @@
                 "strip-indent": "^1.0.1"
             }
         },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "requires": {
-                "is-equal-shallow": "^0.1.3"
-            }
-        },
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -2698,11 +2188,6 @@
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
             }
-        },
-        "remove-trailing-separator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
         },
         "repeat-element": {
             "version": "1.1.3",
@@ -2731,6 +2216,14 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "responselike": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+            "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+            "requires": {
+                "lowercase-keys": "^1.0.0"
+            }
         },
         "ret": {
             "version": "0.1.15",
@@ -2767,14 +2260,14 @@
             }
         },
         "semver": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
         "semver-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-            "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+            "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw=="
         },
         "semver-truncate": {
             "version": "1.1.2",
@@ -2783,11 +2276,6 @@
             "requires": {
                 "semver": "^5.3.0"
             }
-        },
-        "set-immediate-shim": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
         },
         "set-value": {
             "version": "2.0.0",
@@ -2930,6 +2418,22 @@
                 }
             }
         },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "requires": {
+                "is-plain-obj": "^1.0.0"
+            }
+        },
+        "sort-keys-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+            "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+            "requires": {
+                "sort-keys": "^1.0.0"
+            }
+        },
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2952,24 +2456,19 @@
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
-        "sparkles": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
-        },
         "spdx-correct": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+            "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
@@ -2981,9 +2480,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+            "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
         },
         "split-string": {
             "version": "3.1.0",
@@ -3002,11 +2501,6 @@
                 "console-stream": "^0.1.1",
                 "lpad-align": "^1.0.1"
             }
-        },
-        "stat-mode": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-            "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
         },
         "static-extend": {
             "version": "0.1.2",
@@ -3027,23 +2521,14 @@
                 }
             }
         },
-        "stream-combiner2": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-            "requires": {
-                "duplexer2": "~0.1.0",
-                "readable-stream": "^2.0.2"
-            }
-        },
-        "stream-shift": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         },
         "string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
                 "safe-buffer": "~5.1.0"
@@ -3051,7 +2536,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
                 "ansi-regex": "^2.0.0"
@@ -3065,31 +2550,17 @@
                 "is-utf8": "^0.2.0"
             }
         },
-        "strip-bom-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "requires": {
-                "first-chunk-stream": "^1.0.0",
-                "strip-bom": "^2.0.0"
-            }
-        },
         "strip-dirs": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
-            "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "requires": {
-                "chalk": "^1.0.0",
-                "get-stdin": "^4.0.1",
-                "is-absolute": "^0.1.5",
-                "is-natural-number": "^2.0.0",
-                "minimist": "^1.1.0",
-                "sum-up": "^1.0.1"
+                "is-natural-number": "^4.0.1"
             }
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-indent": {
@@ -3100,11 +2571,6 @@
                 "get-stdin": "^4.0.1"
             }
         },
-        "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
         "strip-outer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
@@ -3113,30 +2579,22 @@
                 "escape-string-regexp": "^1.0.2"
             }
         },
-        "sum-up": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
-            "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
-            "requires": {
-                "chalk": "^1.0.0"
-            }
-        },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         },
         "tar-stream": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-            "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+            "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
             "requires": {
                 "bl": "^1.0.0",
-                "buffer-alloc": "^1.1.0",
+                "buffer-alloc": "^1.2.0",
                 "end-of-stream": "^1.0.0",
                 "fs-constants": "^1.0.0",
                 "readable-stream": "^2.3.0",
-                "to-buffer": "^1.1.0",
+                "to-buffer": "^1.1.1",
                 "xtend": "^4.0.0"
             }
         },
@@ -3146,93 +2604,23 @@
             "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
         },
         "tempfile": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
-            "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-            "requires": {
-                "os-tmpdir": "^1.0.0",
-                "uuid": "^2.0.1"
-            }
-        },
-        "through2": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-            "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                }
-            }
-        },
-        "through2-filter": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+            "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+            "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
             "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
-            },
-            "dependencies": {
-                "through2": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-                    "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
-                    }
-                }
+                "temp-dir": "^1.0.0",
+                "uuid": "^3.0.1"
             }
         },
-        "time-stamp": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+        "through": {
+            "version": "2.3.8",
+            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "timed-out": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-            "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
-        },
-        "to-absolute-glob": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-            "requires": {
-                "extend-shallow": "^2.0.1"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                }
-            }
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "to-buffer": {
             "version": "1.1.1",
@@ -3291,14 +2679,21 @@
             }
         },
         "tunnel-agent": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
         },
-        "typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        "unbzip2-stream": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz",
+            "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
+            "requires": {
+                "buffer": "^3.0.1",
+                "through": "^2.3.6"
+            }
         },
         "union-value": {
             "version": "1.0.0",
@@ -3330,15 +2725,6 @@
                         "to-object-path": "^0.3.0"
                     }
                 }
-            }
-        },
-        "unique-stream": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-            "requires": {
-                "json-stable-stringify": "^1.0.0",
-                "through2-filter": "^2.0.0"
             }
         },
         "unset-value": {
@@ -3377,11 +2763,6 @@
                 }
             }
         },
-        "unzip-response": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-            "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-        },
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -3395,13 +2776,10 @@
                 "prepend-http": "^1.0.1"
             }
         },
-        "url-regex": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
-            "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
-            "requires": {
-                "ip-regex": "^1.0.1"
-            }
+        "url-to-options": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+            "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
         },
         "use": {
             "version": "3.1.1",
@@ -3414,14 +2792,9 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "uuid": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-            "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        },
-        "vali-date": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
@@ -3432,101 +2805,12 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
-        "vinyl": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-            "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-            "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
-                "replace-ext": "0.0.1"
-            },
-            "dependencies": {
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-                }
-            }
-        },
-        "vinyl-assign": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
-            "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
-            "requires": {
-                "object-assign": "^4.0.1",
-                "readable-stream": "^2.0.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                }
-            }
-        },
-        "vinyl-fs": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-            "requires": {
-                "duplexify": "^3.2.0",
-                "glob-stream": "^5.3.2",
-                "graceful-fs": "^4.0.0",
-                "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "^0.3.0",
-                "lazystream": "^1.0.0",
-                "lodash.isequal": "^4.0.0",
-                "merge-stream": "^1.0.0",
-                "mkdirp": "^0.5.0",
-                "object-assign": "^4.0.0",
-                "readable-stream": "^2.0.4",
-                "strip-bom": "^2.0.0",
-                "strip-bom-stream": "^1.0.0",
-                "through2": "^2.0.0",
-                "through2-filter": "^2.0.0",
-                "vali-date": "^1.0.0",
-                "vinyl": "^1.0.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                },
-                "through2": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-                    "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
-                    }
-                }
-            }
-        },
-        "ware": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
-            "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
-            "requires": {
-                "wrap-fn": "^0.1.0"
-            }
-        },
         "which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "requires": {
                 "isexe": "^2.0.0"
-            }
-        },
-        "wrap-fn": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
-            "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
-            "requires": {
-                "co": "3.1.0"
             }
         },
         "wrappy": {

--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "imagemin-webp-webpack-plugin",
-  "version": "2.0.0",
-  "description": "Webpack plugin which converts images to the WebP format while also keeping the original files.",
-  "author": {
-    "name": "Alexandru Pavaloi",
-    "email": "pava@iampava.com",
-    "url": "https://iampava.com"
-  },
-  "license": "MIT",
-  "main": "plugin.js",
-  "keywords": [
-    "webpack",
-    "plugin",
-    "webp",
-    "imagemin",
-    "images"
-  ],
-  "repository": "https://github.com/iampava/imagemin-webp-webpack-plugin.git",
-  "bugs": "https://github.com/iampava/imagemin-webp-webpack-plugin/issues",
-  "homepage": "https://github.com/iampava/imagemin-webp-webpack-plugin",
-  "dependencies": {
-    "imagemin": "^6.0.0",
-    "imagemin-webp": "^5.0.0"
-  }
+    "name": "imagemin-webp-webpack-plugin",
+    "version": "2.0.0",
+    "description": "Webpack plugin which converts images to the WebP format while also keeping the original files.",
+    "author": {
+        "name": "Alexandru Pavaloi",
+        "email": "pava@iampava.com",
+        "url": "https://iampava.com"
+    },
+    "license": "MIT",
+    "main": "plugin.js",
+    "keywords": [
+        "webpack",
+        "plugin",
+        "webp",
+        "imagemin",
+        "images"
+    ],
+    "repository": "https://github.com/iampava/imagemin-webp-webpack-plugin.git",
+    "bugs": "https://github.com/iampava/imagemin-webp-webpack-plugin/issues",
+    "homepage": "https://github.com/iampava/imagemin-webp-webpack-plugin",
+    "dependencies": {
+        "imagemin": "^6.0.0",
+        "imagemin-webp": "^5.0.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-    "name": "imagemin-webp-webpack-plugin",
-    "version": "2.0.0",
-    "description": "Webpack plugin which converts images to the WebP format while also keeping the original files.",
-    "author": {
-        "name": "Alexandru Pavaloi",
-        "email": "pava@iampava.com",
-        "url": "https://iampava.com"
-    },
-    "license": "MIT",
-    "main": "plugin.js",
-    "keywords": [
-        "webpack",
-        "plugin",
-        "webp",
-        "imagemin",
-        "images"
-    ],
-    "repository": "https://github.com/iampava/imagemin-webp-webpack-plugin.git",
-    "bugs": "https://github.com/iampava/imagemin-webp-webpack-plugin/issues",
-    "homepage": "https://github.com/iampava/imagemin-webp-webpack-plugin",
-    "dependencies": {
-        "imagemin": "^6.0.0",
-        "imagemin-webp": "^4.1.0"
-    }
+  "name": "imagemin-webp-webpack-plugin",
+  "version": "2.0.0",
+  "description": "Webpack plugin which converts images to the WebP format while also keeping the original files.",
+  "author": {
+    "name": "Alexandru Pavaloi",
+    "email": "pava@iampava.com",
+    "url": "https://iampava.com"
+  },
+  "license": "MIT",
+  "main": "plugin.js",
+  "keywords": [
+    "webpack",
+    "plugin",
+    "webp",
+    "imagemin",
+    "images"
+  ],
+  "repository": "https://github.com/iampava/imagemin-webp-webpack-plugin.git",
+  "bugs": "https://github.com/iampava/imagemin-webp-webpack-plugin/issues",
+  "homepage": "https://github.com/iampava/imagemin-webp-webpack-plugin",
+  "dependencies": {
+    "imagemin": "^6.0.0",
+    "imagemin-webp": "^5.0.0"
+  }
 }


### PR DESCRIPTION
Fix #2 
Latest version of [imagemin-webp](https://github.com/imagemin/imagemin-webp/tree/v5.0.0) seems
to fix the issue.

No vulnerabilities reported after running `npm audit`
