### PR TITLE
Add support to config extension overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Default:
       quality:  75
     }
   }],
+  overrideExtension: true,
   detailedLogs: false,
   strict: true
 }
@@ -82,6 +83,14 @@ The main config of the plugin which controls how different file types are conver
 * **options** -the converting options for the images that pass the above RegExp
 
 ⚠ The **options** object is actually the same one from the [imagemin-webp](https://www.npmjs.com/package/imagemin-webp) plugin so check their documentation for the available settings.
+
+#### overrideExtension
+Type: `boolean`<br>
+Default: `true`
+
+By default the plugin will override the original file extension, so you will get: image.png -> image.webp
+
+In case you want to concat '.webp' at the end of the file name, set the config value to false. Ex: image.png -> image.png.webp. It may be useful when using nginx or similar to serve .webp files if http-accept header contains webp adding a suffix to the current image. 
 
 #### detailedLogs
 

--- a/plugin.js
+++ b/plugin.js
@@ -12,12 +12,14 @@ class ImageminWebpWebpackPlugin {
                 quality: 75
             }
         }],
+        overrideExtension = true,
         detailedLogs = false,
         strict = true
     } = {}) {
         this.config = config;
         this.detailedLogs = detailedLogs;
         this.strict = strict;
+        this.overrideExtension = overrideExtension;
     }
 
     apply(compiler) {
@@ -28,7 +30,12 @@ class ImageminWebpWebpackPlugin {
             Promise.all(assetNames.map(name => {
                 for (let i = 0; i < this.config.length; i++) {
                     if (this.config[i].test.test(name)) {
-                        let nameWithoutExtension = name.split(".").slice(0, -1).join(".");
+                        let outputName = name;
+                        if (this.overrideExtension) {
+                            outputName = outputName.split(".").slice(0, -1).join(".");
+                        }
+                        outputName = `${outputName}.webp`;
+
                         let currentAsset = compilation.assets[name];
 
                         return imagemin.buffer(currentAsset.source(), {
@@ -39,8 +46,7 @@ class ImageminWebpWebpackPlugin {
                             if (this.detailedLogs) {
                                 console.log(GREEN, `${savedKB.toFixed(1)} KB saved from '${name}'`);
                             }
-
-                            compilation.assets[`${nameWithoutExtension}.webp`] = {
+                            compilation.assets[outputName] = {
                                 source: () => buffer,
                                 size: () => buffer.length
                             };


### PR DESCRIPTION
This config may be useful when using nginx or similar to serve .webp files if http-accept header contains webp adding a sufix to the current image. 

In this pull request by default the plugin will concat '.webp' at the end of the file name. Ex: image.png -> image.png.webp. It may be useful when using nginx or similar to serve .webp files if http-accept headers contains webp adding a sufix to the current image. 

In case you want to override the file extension, set this config to true and you will get: image.png -> image.webp		 In case you want to override the file extension, set this config to true and you will get: image.png -> image.webp

EDIT: Just seen that this pull request fixes https://github.com/iampava/imagemin-webp-webpack-plugin/issues/8