### PR TITLE
fix: use proper name for for webpack 4.x & 3.x

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -136,7 +136,7 @@ function emitAsset(name, buffer, compilation) {
         })
     } else {
         // webpack 4.x & 3.x
-        compilation.assets[outputName] = {
+        compilation.assets[name] = {
             source: () => buffer,
             size: () => buffer.length
         };


### PR DESCRIPTION
PR with https://github.com/iampava/imagemin-webp-webpack-plugin/pull/57 introduce error of using wrong name `outputName` instead of `name` when using webpack 3 or 4.

Tis PR fix this error 