### PR TITLE
Add feature to skip unchanged images during refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 * Unreleased | 14/03.2022
-    - added `enableCache` option
+    - added `skipUnchanged` option
 
 * V3.3.6 | 19/07.2021
     - added support for Webpack 5 (https://github.com/iampava/imagemin-webp-webpack-plugin/issues/38)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Unreleased | 14/03.2022
+    - added `enableCache` option
+
 * V3.3.6 | 19/07.2021
     - added support for Webpack 5 (https://github.com/iampava/imagemin-webp-webpack-plugin/issues/38)
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ By default the webpack build will fail if any of the images that match your RegE
 
 This option tells the plugin to not crash the build and keep going :)
 
-#### enableCache
+#### skipUnchanged
 
 Type: `boolean`<br>
 Default: `false`

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ By default the webpack build will fail if any of the images that match your RegE
 
 This option tells the plugin to not crash the build and keep going :)
 
+#### enableCache
+
+Type: `boolean`<br>
+Default: `false`
+
+If enabled, unchanged images are skipped during fast-refresh, and only new images are converted.
+
 ## Compatibility & known issues
 
 Recently we updated this plugin to make it compatible with **webpack 5**. Originally it was built for **webpack 4** and earlier versions, so I expect it would be compatible no matter the project :)

--- a/plugin.js
+++ b/plugin.js
@@ -20,14 +20,14 @@ class ImageminWebpWebpackPlugin {
         detailedLogs = false,
         strict = true,
         silent = false,
-        enableCache = false,
+        skipUnchanged = false,
     } = {}) {
         this.config = config;
         this.detailedLogs = detailedLogs;
         this.strict = strict;
         this.overrideExtension = overrideExtension;
         this.silent = silent;
-        this.enableCache = enableCache;
+        this.skipUnchanged = skipUnchanged;
         this.sourceVersions = {};
         this.savedKBs = {};
     }
@@ -58,7 +58,7 @@ class ImageminWebpWebpackPlugin {
                             let currentAsset = compilation.assets[name];
 
                             let hash = undefined;
-                            if (this.enableCache) {
+                            if (this.skipUnchanged) {
                                 hash = crypto.createHash('sha256').update(currentAsset.source()).digest('hex');
 
                                 if (this.sourceVersions[outputName] === hash) {
@@ -87,7 +87,7 @@ class ImageminWebpWebpackPlugin {
 
                                     emitAsset(outputName, buffer, compilation);
                                     
-                                    if (this.enableCache && hash !== undefined) {
+                                    if (this.skipUnchanged && hash !== undefined) {
                                         this.savedKBs[hash] = savedKB;
                                     }
 

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,7 @@
 const imagemin = require('imagemin');
 const webp = require('imagemin-webp');
 const gif2webp = require('imagemin-gif2webp');
+const crypto = require('crypto');
 
 const GREEN = '\x1b[32m%s\x1b[0m';
 const RED = '\x1b[31m%s\x1b[0m';
@@ -18,19 +19,24 @@ class ImageminWebpWebpackPlugin {
         overrideExtension = true,
         detailedLogs = false,
         strict = true,
-        silent = false
+        silent = false,
+        enableCache = false,
     } = {}) {
         this.config = config;
         this.detailedLogs = detailedLogs;
         this.strict = strict;
         this.overrideExtension = overrideExtension;
         this.silent = silent;
+        this.enableCache = enableCache;
+        this.sourceVersions = {};
+        this.savedKBs = {};
     }
 
     apply(compiler) {
         const onEmit = (compilation, cb) => {
             let assetNames = Object.keys(compilation.assets);
             let nrOfImagesFailed = 0;
+            let nrOfImagesSkipped = 0;
 
             if (this.silent && this.detailedLogs) {
                 compilation.warnings.push(new Error(`ImageminWebpWebpackPlugin: both the 'silent' and 'detailedLogs' options are true. Overriding 'detailedLogs' and disabling all console output.`));
@@ -51,6 +57,20 @@ class ImageminWebpWebpackPlugin {
 
                             let currentAsset = compilation.assets[name];
 
+                            let hash = undefined;
+                            if (this.enableCache) {
+                                hash = crypto.createHash('sha256').update(currentAsset.source()).digest('hex');
+
+                                if (this.sourceVersions[outputName] === hash) {
+                                    nrOfImagesSkipped++;
+                                    if (this.detailedLogs && !this.silent) {
+                                        console.log(GREEN, `Unchanged and skipped: '${name}'`);
+                                    }
+                                    return Promise.resolve(this.savedKBs[hash] ?? 0);
+                                }
+                                this.sourceVersions[outputName] = hash;
+                            }
+
                             return imagemin
                                 .buffer(currentAsset.source(), {
                                     plugins: [
@@ -66,6 +86,11 @@ class ImageminWebpWebpackPlugin {
                                     }
 
                                     emitAsset(outputName, buffer, compilation);
+                                    
+                                    if (this.enableCache && hash !== undefined) {
+                                        this.savedKBs[hash] = savedKB;
+                                    }
+
                                     return savedKB;
                                 })
                                 .catch(err => {
@@ -95,6 +120,9 @@ class ImageminWebpWebpackPlugin {
                         console.log(GREEN, `imagemin-webp-webpack-plugin: ${Math.floor(totalKBSaved / 100) / 10} MB saved`);
                     }
 
+                    if (nrOfImagesSkipped > 0) {
+                        console.log(GREEN, `imagemin-webp-webpack-plugin: ${nrOfImagesSkipped} images were unchanged and skipped`);
+                    }
                     if (nrOfImagesFailed > 0) {
                         console.log(RED, `imagemin-webp-webpack-plugin: ${nrOfImagesFailed} images failed to convert to webp`);
                     }


### PR DESCRIPTION
Hello, thank you for publishing this great plugin.

This pull request fixes #14 , adding `skipUnchanged` option.

## Implementation Summary 
When `skipUnchanged` is `true`, it stores the SHA-256 hash value of each images to be converted. Like below:

```
// ImageminWebpWebpackPlugin.sourceVersions
{
  'assets/bicycle_2.webp': 'e3ab38b7bea9e13f7ec748019a92e45b8c13dbafcb612cb07ef59f6dc346a866',
  'assets/cookie-monster.webp': 'ef8a7672e385b4ab734129baf16db2597b19547580c9a88f9a1c81b5faa54953',
  'assets/images/folder.with.dots/inner-folder/bicycle_1.webp': '93cc700fbf54c93c9503166343c9f3d2bfcbc98d2049bc38972e8501d8c26c20'
}
```

Then during refreshes, conversions are skipped if the target image's hash is already stored.

Note: This implementation is inspired by an official example from webpack for monitoring changed chunks.
https://webpack.js.org/contribute/plugin-patterns/#changed-chunks

## Experimental results
Experiments on test projects showed this change saves a considerable ratio of runtime. 🎉 

### Webpack 5: ~800ms → ~150ms

|  Original  |  With `skipUnchanged`  |
| ---- | ---- |
|  <img width="692" alt="screenshot 2022-03-14 16 46 18" src="https://user-images.githubusercontent.com/36780394/158135596-09c47313-77b5-4667-b564-ab9e48124751.png">  |  <img width="690" alt="screenshot 2022-03-14 16 45 46" src="https://user-images.githubusercontent.com/36780394/158135635-57026776-82fd-4ae1-955e-60485df18fd5.png"> |

It detects and converts newly added/modified images:
<img width="650" alt="screenshot 2022-03-14 17 48 49" src="https://user-images.githubusercontent.com/36780394/158137054-d789f0bb-01dd-493c-8edd-829eb4aa82db.png">

### Webpack 4: ~1300ms → ~350ms

|  Original  |  With `skipUnchanged`  |
| ---- | ---- |
| <img width="863" alt="screenshot 2022-03-14 16 49 23" src="https://user-images.githubusercontent.com/36780394/158135976-d2d3e890-1b61-45d6-b341-b949f10b5ab5.png"> | <img width="862" alt="screenshot 2022-03-14 16 50 56" src="https://user-images.githubusercontent.com/36780394/158136047-ea9c6cae-f29d-47bf-a1f5-f7329eace1a4.png"> |

